### PR TITLE
Remove initial filter on problems

### DIFF
--- a/problems/openproblem-format.js
+++ b/problems/openproblem-format.js
@@ -1,6 +1,6 @@
 var openProblemCounter = 0;
 var problems;
-var openProblemFilter = "Classical";
+var openProblemFilter = "";
 
 function loadMoreOpenProblems(amount, idText, idButton){
   var presDisplay = document.getElementById(idText);


### PR DESCRIPTION
I just noticed that 2 open problems (about convex integral and topological measure) do not show up initially. This is because those 2 do not contain the initial filter "Classical".